### PR TITLE
stick to classic build tool

### DIFF
--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -1,6 +1,7 @@
 steps:
   mtaBuild:
     buildTarget: 'NEO'
+    mtaBuildTool: 'classic'
   neoDeploy:
     deployMode: mta
     neo:


### PR DESCRIPTION
Later on we should update to project in order to be able to build with the new default